### PR TITLE
Port/moes zm4lt2

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1161,7 +1161,7 @@ MODULE_MOES_ZM4LT2_TS0002:
   tuya_module: ZT2S
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: criiahcg;TS0002-MS;BB1u;LC3;SB4u;RC2;SB5u;RD2;
+  config_str: criiahcg;TS0002-MS;BB1u;LC3;SB5u;RD2;SB4u;RC2;
   alt_config_str: null
   old_manufacturer_names: null
   old_zb_models: null

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1171,7 +1171,7 @@ MODULE_MOES_ZM4LT2_TS0002:
   build: yes
   status: fully_supported
   info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/issues/167
+  threads: https://github.com/romasku/tuya-zigbee-switch/issues/284
   store: https://www.aliexpress.com/item/1005009640015785.html
 MODULE_MOES_ZM4LT3_TS0003:
   human_name: Moes ZM4LT3


### PR DESCRIPTION
## Summary

Add pinout configuration for the Moes ZM4LT2 2-gang Zigbee switch module.
Now fully tested and with fixed order

## Device Information

- **Model:** Moes ZM4LT2
![Image](https://github.com/user-attachments/assets/d33295a7-24ce-4423-b6f7-cae1cef14f8e)

## Pinout

| Pin | Function | Notes |
|-----|----------|-------|
| C2 | Relay L1 | Active High |
| D2 | Relay L2 | Active High |
| C3 | LED | Active High |
| B1 | Button | Active Low, Pull-up on board |
| B4 | Switch Input S1 | Active Low, Pull-up on board |
| B5 | Switch Input S2 | Active Low, Pull-up on board |

**Config string:** `criiahcg;TS0002-MS;BB1u;LC3;SB5u;RD2;SB4u;RC2;`

Related info:
https://github.com/romasku/tuya-zigbee-switch/issues/284